### PR TITLE
Add The Inhabitant: procedural character with live text reflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "uiglow",
       "version": "0.1.0",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.8",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-popover": "^1.1.14",
@@ -432,6 +433,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.8",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-popover": "^1.1.14",

--- a/src/app/experiences/inhabitant/Ladder.jsx
+++ b/src/app/experiences/inhabitant/Ladder.jsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { rungYs } from './character/climb';
+import { LADDER } from './constants';
+
+// Ladder presence is React state (discrete); its geometry is pure data from
+// the sim. Grows via scaleY from `growFrom` so a downward move grows down
+// from the top and an upward move grows up from the bottom.
+export default function Ladder({ ladder, leaving, width, height }) {
+  const [grown, setGrown] = useState(false);
+
+  useEffect(() => {
+    setGrown(false);
+    const raf = requestAnimationFrame(() => requestAnimationFrame(() => setGrown(true)));
+    return () => cancelAnimationFrame(raf);
+  }, [ladder]);
+
+  if (!ladder) return null;
+
+  const half = ladder.width / 2;
+  const originY = ladder.growFrom === 'top' ? ladder.railTop : ladder.railBottom;
+  const scale = leaving ? 1 : grown ? 1 : 0.02;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className="absolute inset-0 z-10 pointer-events-none text-slate-500 dark:text-slate-400"
+      aria-hidden="true"
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth={3}
+        strokeLinecap="round"
+        style={{
+          transform: `scaleY(${scale})`,
+          transformOrigin: `${ladder.x}px ${originY}px`,
+          transition: `transform ${LADDER.GROW_TIME}s cubic-bezier(0.34, 1.3, 0.64, 1), opacity ${LADDER.FADE_TIME}s ease`,
+          opacity: leaving ? 0 : 1,
+        }}
+      >
+        <line x1={ladder.x - half} y1={ladder.railTop} x2={ladder.x - half} y2={ladder.railBottom} />
+        <line x1={ladder.x + half} y1={ladder.railTop} x2={ladder.x + half} y2={ladder.railBottom} />
+        {rungYs(ladder).map((y) => (
+          <line key={y} x1={ladder.x - half} y1={y} x2={ladder.x + half} y2={y} strokeWidth={2.5} />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/src/app/experiences/inhabitant/Stage.jsx
+++ b/src/app/experiences/inhabitant/Stage.jsx
@@ -1,0 +1,388 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import CharacterSvg from './character/CharacterSvg';
+import Ladder from './Ladder';
+import { createSim, plan, advance } from './character/stateMachine';
+import { updateWeights, computeTargets } from './character/poses';
+import { solvePose } from './character/rig';
+import { drawCharacter } from './character/render';
+import { startLoop } from './core/loop';
+import { createSpring, stepSpring, snapSpring } from './core/spring';
+import { buildObstacle, obstacleMoved } from './text/obstacle';
+import { prepareText, reflow, naturalLineCount, pretextSupported } from './text/reflow';
+import { CHAR, STAGE, TEXT, LADDER } from './constants';
+
+const BODY_TEXT =
+  'This little figure is not a video, and not a sprite sheet. Every step is computed live: an ' +
+  'arrive-steering controller decides how the body accelerates and eases to a stop, planted feet ' +
+  'grip the page while the hips glide past, and a two-bone solver bends each knee and elbow with ' +
+  'the law of cosines. Click anywhere on this page and it will walk there. Click higher or lower ' +
+  'and it will raise a ladder of exactly the right length, grip the rungs hand over hand, and ' +
+  'climb. The paragraph you are reading is part of the simulation too. Each frame, the character ' +
+  'reports the rectangle it occupies, and these lines are re-broken around it — to the left and ' +
+  'right of the intrusion — by pretext, a text layout engine that measures and wraps entirely in ' +
+  'arithmetic, with no DOM reflow at all. Move your pointer and the eyes follow. Stop moving, and ' +
+  'it just stands there, breathing. It lives here, between the lines. None of this is keyframed. ' +
+  'The walk is not a clip that plays; it is a negotiation, resolved sixty times a second, between ' +
+  'where the body wants to be and where the feet last touched down. Send the character on a long ' +
+  'journey and the stride stretches out to full speed; interrupt it mid-step and it simply ' +
+  're-plans, because there is nothing to rewind — only a target that moved. The same is true of ' +
+  'the climb. The ladder is not a drawing, it is a data structure, and every rung you see is a ' +
+  'coordinate the hands and feet are solving against. Change your mind mid-climb and the creature ' +
+  'finishes to the nearest rung before turning around, the way anything with weight would have ' +
+  'to. And the text — this text — is the strangest instrument in the room. Most pages treat a ' +
+  'paragraph as furniture, arranged once and bolted down. Here the paragraph is elastic: it ' +
+  'measures itself, breaks itself, and steps aside, and because the measuring is pure arithmetic ' +
+  'it costs almost nothing to do again next frame. If you take one idea away, let it be this: ' +
+  'interfaces feel alive not when they move, but when they yield.';
+
+const LINE_CLASS = 'text-[17px] leading-[28px] text-slate-700 dark:text-slate-300';
+const LINE_FONT = { fontFamily: 'var(--font-geist), sans-serif' };
+
+export default function Stage() {
+  const [mode, setMode] = useState('loading'); // loading | live | static | mobile
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [stageH, setStageH] = useState(null); // px once the text is measured; 100vh before
+  const [ladderUi, setLadderUi] = useState(null); // { data, leaving }
+
+  const stageRef = useRef(null);
+  const measureRef = useRef(null);
+  const charRefs = useRef({});
+  const lineEls = useRef([]);
+  const lineSprings = useRef([]);
+
+  const simRef = useRef(null);
+  const geomRef = useRef(null);
+  const preparedRef = useRef(null);
+  const lastObRef = useRef(null);
+  const forceReflowRef = useRef(true);
+  const ladderRef = useRef(null);
+  const envRef = useRef(null);
+  const pointerRef = useRef({ x: 0, y: 0 });
+  const downPosRef = useRef(null);
+  const faceRef = useRef({
+    lookX: createSpring(0),
+    lookY: createSpring(0),
+    tilt: createSpring(0),
+    blinkTimer: 3,
+    blinkT: -1, // >= 0 while mid-blink
+  });
+
+  // Decide the render mode after mount (needs window)
+  useEffect(() => {
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    if (coarse || window.innerWidth < 900) {
+      setMode('mobile');
+      return;
+    }
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    setMode(reduced || !pretextSupported() ? 'static' : 'live');
+  }, []);
+
+  // The whole live experience: one clock drives sim, IK, springs, and reflow.
+  useEffect(() => {
+    if (mode !== 'live') return;
+    let stop = null;
+    let cancelled = false;
+    const stageEl = stageRef.current;
+
+    const measureStage = () => {
+      const rect = stageEl.getBoundingClientRect();
+      setSize({ w: rect.width, h: rect.height });
+      // the stage fills the viewport; the text column is centered inside it
+      const colW = Math.min(STAGE.COL_W, rect.width - 2 * STAGE.PAD_X);
+      const x0 = (rect.width - colW) / 2;
+      geomRef.current = {
+        x0,
+        x1: x0 + colW,
+        top: STAGE.PARA_TOP,
+        maxH: rect.height - STAGE.PARA_TOP - STAGE.PAD_BOTTOM,
+      };
+      forceReflowRef.current = true;
+      return rect;
+    };
+
+    const rect = measureStage();
+    simRef.current = createSim(rect.width * 0.58, STAGE.PARA_TOP + 240);
+    lineSprings.current = Array.from({ length: TEXT.POOL }, () => {
+      const s = createSpring(0);
+      s.target = 0;
+      return s;
+    });
+
+    const env = {
+      spawnLadder: (ladder) => {
+        ladderRef.current = ladder;
+        setLadderUi({ data: ladder, leaving: false });
+      },
+      removeLadder: () => {
+        const l = ladderRef.current;
+        if (!l) return;
+        ladderRef.current = null;
+        setLadderUi({ data: l, leaving: true });
+        setTimeout(() => {
+          setLadderUi((prev) => (prev && prev.leaving ? null : prev));
+        }, LADDER.FADE_TIME * 1000 + 60);
+      },
+    };
+    envRef.current = env;
+
+    const applyPlacement = (placed) => {
+      for (let i = 0; i < TEXT.POOL; i++) {
+        const el = lineEls.current[i];
+        const spring = lineSprings.current[i];
+        if (!el) continue;
+        const p = placed[i];
+        if (p) {
+          if (el.textContent !== p.text) el.textContent = p.text;
+          el.style.top = `${p.y}px`;
+          if (el.style.visibility !== 'visible') {
+            snapSpring(spring, p.x); // don't fly in from stale positions
+            el.style.left = `${p.x}px`;
+            el.style.visibility = 'visible';
+          }
+          spring.target = p.x;
+        } else if (el.style.visibility === 'visible') {
+          el.style.visibility = 'hidden';
+        }
+      }
+    };
+
+    const stepFace = (dt, joints) => {
+      const f = faceRef.current;
+      const p = pointerRef.current;
+      const dx = p.x - joints.headC.x;
+      const dy = p.y - joints.headC.y;
+      const d = Math.hypot(dx, dy) || 1;
+      const reach = Math.min(2.2, d * 0.05);
+      // underdamped: slight overshoot sells the look-at
+      stepSpring(f.lookX, (dx / d) * reach, 120, 9, dt);
+      stepSpring(f.lookY, (dy / d) * reach, 120, 9, dt);
+      stepSpring(f.tilt, Math.max(-0.12, Math.min(0.12, dx * 0.0006)), 60, 10, dt);
+
+      let blinkScale = 1;
+      if (f.blinkT >= 0) {
+        f.blinkT += dt;
+        const BLINK = 0.22;
+        blinkScale = f.blinkT >= BLINK ? 1 : 0.1 + 0.9 * Math.abs(1 - (2 * f.blinkT) / BLINK);
+        if (f.blinkT >= BLINK) {
+          f.blinkT = -1;
+          f.blinkTimer = 2.5 + Math.random() * 3.5;
+        }
+      } else {
+        f.blinkTimer -= dt;
+        if (f.blinkTimer <= 0) f.blinkT = 0;
+      }
+      return {
+        lookX: f.lookX.value,
+        lookY: f.lookY.value,
+        headTilt: f.tilt.value,
+        blinkScale,
+        facing: simRef.current.facing,
+      };
+    };
+
+    const tick = (dt, t) => {
+      const sim = simRef.current;
+      advance(sim, dt, env);
+      updateWeights(sim, dt);
+
+      const ladder = ladderRef.current;
+      const targets = computeTargets(sim, ladder, t);
+      const joints = solvePose(sim, targets);
+      const face = stepFace(dt, joints);
+      drawCharacter(charRefs.current, joints, face);
+
+      if (preparedRef.current) {
+        const ob = buildObstacle(sim, ladder);
+        if (forceReflowRef.current || obstacleMoved(ob, lastObRef.current)) {
+          forceReflowRef.current = false;
+          lastObRef.current = ob;
+          applyPlacement(reflow(preparedRef.current, ob, geomRef.current));
+        }
+      }
+
+      // per-line horizontal easing: text flows instead of teleporting
+      for (let i = 0; i < TEXT.POOL; i++) {
+        const el = lineEls.current[i];
+        const spring = lineSprings.current[i];
+        if (!el || el.style.visibility !== 'visible') continue;
+        stepSpring(spring, spring.target, TEXT.X_STIFFNESS, TEXT.X_DAMPING, dt);
+        el.style.left = `${Math.round(spring.value * 100) / 100}px`;
+      }
+    };
+
+    (async () => {
+      await document.fonts.ready;
+      if (cancelled) return;
+      // next/font mangles family names; pretext needs the exact rendered font,
+      // so build the measurement string from the live computed style.
+      const cs = getComputedStyle(measureRef.current);
+      preparedRef.current = prepareText(BODY_TEXT, `${cs.fontSize} ${cs.fontFamily}`);
+      // size the stage to fit the text plus slack for obstacle-displaced lines,
+      // never shorter than the viewport (the whole viewport stays clickable)
+      const lines = naturalLineCount(preparedRef.current, geomRef.current.x1 - geomRef.current.x0);
+      setStageH(
+        Math.max(
+          window.innerHeight,
+          STAGE.PARA_TOP + (lines + STAGE.SLACK_LINES) * TEXT.LINE_H + STAGE.PAD_BOTTOM
+        )
+      );
+      forceReflowRef.current = true;
+      if (!cancelled) stop = startLoop(tick, { observe: stageEl });
+    })();
+
+    const ro = new ResizeObserver(() => {
+      const r = measureStage();
+      const sim = simRef.current;
+      if (sim) sim.x = Math.min(Math.max(sim.x, 40), r.width - 40);
+    });
+    ro.observe(stageEl);
+
+    return () => {
+      cancelled = true;
+      if (stop) stop();
+      ro.disconnect();
+    };
+  }, [mode]);
+
+  // Static fallback: draw the rest pose once, text flows normally.
+  useEffect(() => {
+    if (mode !== 'static') return;
+    const rect = stageRef.current.getBoundingClientRect();
+    setSize({ w: rect.width, h: rect.height });
+    const sim = createSim(rect.width * 0.15, STAGE.PARA_TOP - 10);
+    const targets = computeTargets(sim, null, 0);
+    const joints = solvePose(sim, targets);
+    drawCharacter(charRefs.current, joints, {
+      lookX: 0, lookY: 0, headTilt: 0, blinkScale: 1, facing: 1,
+    });
+  }, [mode]);
+
+  const stageLocal = (e) => {
+    const r = stageRef.current.getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  };
+
+  const onPointerMove = (e) => {
+    pointerRef.current = stageLocal(e);
+  };
+
+  const onPointerDown = (e) => {
+    downPosRef.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const onClick = (e) => {
+    if (mode !== 'live' || !simRef.current) return;
+    const down = downPosRef.current;
+    if (down && Math.hypot(e.clientX - down.x, e.clientY - down.y) > 5) return; // drag
+    if (window.getSelection && String(window.getSelection())) return; // text selection
+    const p = stageLocal(e);
+    const x = Math.min(Math.max(p.x, 34), size.w - 34);
+    const y = Math.min(Math.max(p.y, CHAR.H + 14), size.h - 14);
+    plan(simRef.current, { x, y }, envRef.current);
+  };
+
+  if (mode === 'mobile') {
+    return (
+      <main className="min-h-screen w-full bg-slate-50 dark:bg-slate-950 flex items-center justify-center p-8">
+        <div className="text-center max-w-sm">
+          <h1
+            className="text-4xl text-slate-900 dark:text-slate-100 mb-4"
+            style={{ fontFamily: 'var(--font-instrument), serif' }}
+          >
+            The Inhabitant
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400" style={LINE_FONT}>
+            This one needs a pointer and some room to walk around. Open it on a desktop.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen w-full bg-slate-50 dark:bg-slate-950">
+      <div
+        ref={stageRef}
+        onClick={onClick}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        className="relative w-full cursor-crosshair"
+        style={{ height: stageH ?? '100vh' }}
+      >
+        <header className="absolute top-10 left-0 right-0 text-center pointer-events-none z-0">
+          <h1
+            className="text-5xl text-slate-900 dark:text-slate-100"
+            style={{ fontFamily: 'var(--font-instrument), serif' }}
+          >
+            The Inhabitant
+          </h1>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400" style={LINE_FONT}>
+            {mode === 'live'
+              ? 'Click in the text to send it walking. Click higher or lower for the ladder.'
+              : 'A creature living between the lines.'}
+          </p>
+        </header>
+
+        {/* real, in-order copy for screen readers; the pool below is presentational */}
+        <p className="sr-only">{BODY_TEXT}</p>
+
+        {mode === 'static' ? (
+          <p
+            className={LINE_CLASS}
+            style={{
+              ...LINE_FONT,
+              position: 'absolute',
+              top: STAGE.PARA_TOP,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: `min(${STAGE.COL_W}px, calc(100% - ${2 * STAGE.PAD_X}px))`,
+            }}
+            aria-hidden="true"
+          >
+            {BODY_TEXT}
+          </p>
+        ) : (
+          <div aria-hidden="true">
+            <span
+              ref={measureRef}
+              className={LINE_CLASS}
+              style={{ ...LINE_FONT, position: 'absolute', visibility: 'hidden' }}
+            >
+              x
+            </span>
+            {Array.from({ length: TEXT.POOL }, (_, i) => (
+              <span
+                key={i}
+                ref={(el) => {
+                  lineEls.current[i] = el;
+                }}
+                className={LINE_CLASS}
+                style={{
+                  ...LINE_FONT,
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  whiteSpace: 'pre',
+                  visibility: 'hidden',
+                }}
+              />
+            ))}
+          </div>
+        )}
+
+        {ladderUi && (
+          <Ladder
+            ladder={ladderUi.data}
+            leaving={ladderUi.leaving}
+            width={size.w}
+            height={size.h}
+          />
+        )}
+        <CharacterSvg ref={charRefs} width={size.w} height={size.h} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/experiences/inhabitant/character/CharacterSvg.jsx
+++ b/src/app/experiences/inhabitant/character/CharacterSvg.jsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { CHAR } from '../constants';
+
+// Placeholder line-figure. The parent gets a refs object (via ref) whose nodes
+// render.js writes every frame. Decorative: aria-hidden, no pointer events.
+const CharacterSvg = forwardRef(function CharacterSvg({ width, height }, ref) {
+  const refs = useRef({});
+  useImperativeHandle(ref, () => refs.current, []);
+  const set = (key) => (el) => {
+    refs.current[key] = el;
+  };
+
+  const limb = { strokeWidth: 4, strokeLinecap: 'round' };
+  const far = { ...limb, opacity: 0.55 };
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className="absolute inset-0 z-20 pointer-events-none text-slate-800 dark:text-slate-200"
+      aria-hidden="true"
+    >
+      <g stroke="currentColor" fill="none">
+        {/* far side */}
+        <line ref={set('thighR')} {...far} />
+        <line ref={set('shinR')} {...far} />
+        <line ref={set('upperR')} {...far} />
+        <line ref={set('foreR')} {...far} />
+        {/* body */}
+        <line ref={set('torso')} strokeWidth={5} strokeLinecap="round" />
+        {/* near side */}
+        <line ref={set('thighL')} {...limb} />
+        <line ref={set('shinL')} {...limb} />
+        <line ref={set('upperL')} {...limb} />
+        <line ref={set('foreL')} {...limb} />
+        {/* head */}
+        <g ref={set('headG')}>
+          <circle
+            r={CHAR.headR}
+            strokeWidth={3.5}
+            className="fill-slate-50 dark:fill-slate-950"
+          />
+          <g ref={set('eyesG')} stroke="none" fill="currentColor">
+            <circle cx={-2.1} cy={0} r={1.5} />
+            <circle cx={2.1} cy={0} r={1.5} />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+});
+
+export default CharacterSvg;

--- a/src/app/experiences/inhabitant/character/climb.js
+++ b/src/app/experiences/inhabitant/character/climb.js
@@ -1,0 +1,54 @@
+import { CLIMB } from '../constants';
+
+// The ladder owns its rung geometry; climbing limbs only ever target real rungs.
+
+export function rungYs(ladder) {
+  const ys = [];
+  for (let y = ladder.railTop + ladder.rungSpacing / 2; y < ladder.railBottom; y += ladder.rungSpacing) {
+    ys.push(y);
+  }
+  return ys;
+}
+
+export function nearestRung(ladder, y) {
+  const first = ladder.railTop + ladder.rungSpacing / 2;
+  const k = Math.round((y - first) / ladder.rungSpacing);
+  const count = Math.floor((ladder.railBottom - first) / ladder.rungSpacing) + 1;
+  const kk = Math.max(0, Math.min(count - 1, k));
+  return first + kk * ladder.rungSpacing;
+}
+
+export function makeClimbLimbs(ladder, sim, shoulderY) {
+  // Each limb holds a plant (a real rung position) and steps to the adjacent
+  // rung during its reach window. Diagonal pairs share a phase offset.
+  const lx = ladder.x;
+  return {
+    handL: { plant: { x: lx - 7, y: nearestRung(ladder, shoulderY - 8) }, offset: 0 },
+    footR: { plant: { x: lx + 6, y: nearestRung(ladder, sim.y - 2) }, offset: 0.06 },
+    handR: { plant: { x: lx + 7, y: nearestRung(ladder, shoulderY - 8 - ladder.rungSpacing) }, offset: 0.5 },
+    footL: { plant: { x: lx - 6, y: nearestRung(ladder, sim.y - 2 - ladder.rungSpacing) }, offset: 0.56 },
+  };
+}
+
+// phase: global climb phase (advances with vertical distance / rungSpacing).
+// dir: +1 descending (y grows), -1 ascending.
+export function climbLimbTarget(limb, phase, dir, ladder, bowSign) {
+  const p = (phase + limb.offset) % 1;
+  if (p < CLIMB.HOLD) {
+    return { target: { ...limb.plant }, committed: false };
+  }
+  const t = (p - CLIMB.HOLD) / (1 - CLIMB.HOLD);
+  const nextY = nearestRung(ladder, limb.plant.y + dir * ladder.rungSpacing);
+  const y = limb.plant.y + (nextY - limb.plant.y) * t;
+  const bow = Math.sin(t * Math.PI) * CLIMB.REACH_BOW * bowSign;
+  return { target: { x: limb.plant.x + bow, y }, committed: false, reachingTo: nextY };
+}
+
+// Commit a limb's plant when its phase wraps from reach back into hold.
+export function stepClimbLimb(limb, prevPhase, phase, dir, ladder) {
+  const prev = (prevPhase + limb.offset) % 1;
+  const cur = (phase + limb.offset) % 1;
+  if (prev > cur) {
+    limb.plant.y = nearestRung(ladder, limb.plant.y + dir * ladder.rungSpacing);
+  }
+}

--- a/src/app/experiences/inhabitant/character/ik.js
+++ b/src/app/experiences/inhabitant/character/ik.js
@@ -1,0 +1,26 @@
+// Two-bone IK via the law of cosines. bendDir picks which side the middle
+// joint (knee/elbow) bows toward. y points down, angles in radians.
+
+export function solveTwoBone(root, target, l1, l2, bendDir) {
+  const dx = target.x - root.x;
+  const dy = target.y - root.y;
+  const maxReach = l1 + l2;
+  const minReach = Math.abs(l1 - l2);
+  const dist = Math.min(Math.max(Math.hypot(dx, dy), minReach + 1e-4), maxReach - 1e-4);
+  const base = Math.atan2(dy, dx);
+  const cosA = (l1 * l1 + dist * dist - l2 * l2) / (2 * l1 * dist);
+  const a = Math.acos(Math.min(1, Math.max(-1, cosA)));
+  const upperAngle = base + bendDir * a;
+  const knee = {
+    x: root.x + Math.cos(upperAngle) * l1,
+    y: root.y + Math.sin(upperAngle) * l1,
+  };
+  // The end effector sits at the clamped distance along the solved chain, so
+  // recompute it instead of trusting the raw target (which may be out of reach).
+  const lowerAngle = Math.atan2(target.y - knee.y, target.x - knee.x);
+  const end = {
+    x: knee.x + Math.cos(lowerAngle) * l2,
+    y: knee.y + Math.sin(lowerAngle) * l2,
+  };
+  return { knee, end, upperAngle, lowerAngle };
+}

--- a/src/app/experiences/inhabitant/character/locomotion.js
+++ b/src/app/experiences/inhabitant/character/locomotion.js
@@ -1,0 +1,34 @@
+import { WALK } from '../constants';
+
+// Arrive steering: acceleration-limited velocity toward a target with an
+// arrival radius, so the character eases out of a move instead of gliding
+// at constant speed and stopping dead.
+export function arrive(pos, vel, target, maxSpeed, accel, slowRadius, dt) {
+  const toTarget = target - pos;
+  const dist = Math.abs(toTarget);
+  const desiredSpeed = dist > slowRadius ? maxSpeed : maxSpeed * (dist / slowRadius);
+  const desiredVel = Math.sign(toTarget) * desiredSpeed;
+  const maxDv = accel * dt;
+  vel += Math.max(-maxDv, Math.min(maxDv, desiredVel - vel));
+  return { pos: pos + vel * dt, vel };
+}
+
+// Foot planting: during stance the foot's world position is FIXED at its
+// plant point while the hip glides past; during swing it lifts on a sine arc
+// toward the next plant point.
+export function footTarget(hipX, groundY, facing, phase, plant, stride) {
+  if (phase < WALK.STANCE) {
+    return { x: plant.x, y: groundY };
+  }
+  const t = (phase - WALK.STANCE) / (1 - WALK.STANCE);
+  const nextX = hipX + facing * (stride / 2);
+  const x = plant.x + (nextX - plant.x) * t;
+  const lift = Math.sin(t * Math.PI) * WALK.STEP_HEIGHT;
+  return { x, y: groundY - lift };
+}
+
+// Detects the swing->stance crossing so the caller can commit a new plant.
+export function crossedToStance(prevPhase, phase) {
+  // phase wraps 0..1; stance begins at 0
+  return prevPhase > phase; // wrapped past 1.0 back into stance
+}

--- a/src/app/experiences/inhabitant/character/poses.js
+++ b/src/app/experiences/inhabitant/character/poses.js
@@ -1,0 +1,155 @@
+import { CHAR, WALK, CLIMB, BLEND_RATE } from '../constants';
+import { footTarget, crossedToStance } from './locomotion';
+import { climbLimbTarget } from './climb';
+
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
+const TAU = Math.PI * 2;
+
+// Ramp state weights toward the active state. Walk weight follows speed so
+// the gait fades in/out instead of popping; everything is then normalized.
+export function updateWeights(sim, dt) {
+  const target = { idle: 0, walk: 0, climb: 0 };
+  if (sim.mode === 'walk') {
+    target.walk = clamp01(Math.abs(sim.vx) / (WALK.MAX_SPEED * 0.45));
+    target.idle = 1 - target.walk;
+  } else if (sim.mode === 'climb') {
+    target.climb = 1;
+  } else {
+    target.idle = 1;
+  }
+  const k = Math.min(1, dt * BLEND_RATE);
+  let sum = 0;
+  for (const s of ['idle', 'walk', 'climb']) {
+    sim.weights[s] += (target[s] - sim.weights[s]) * k;
+    sum += sim.weights[s];
+  }
+  for (const s of ['idle', 'walk', 'climb']) sim.weights[s] /= sum;
+}
+
+function idleTargets(sim, t) {
+  const hipY = sim.y - CHAR.legReach;
+  const shoulderY = hipY - CHAR.torso;
+  const handDrop = CHAR.upperArm + CHAR.foreArm - 3;
+  return {
+    feetL: { x: sim.feetPlant.L.x, y: sim.y },
+    feetR: { x: sim.feetPlant.R.x, y: sim.y },
+    handL: { x: sim.x - CHAR.shoulderHalf - 2, y: shoulderY + handDrop },
+    handR: { x: sim.x + CHAR.shoulderHalf + 2, y: shoulderY + handDrop },
+    hipLift: Math.sin(t * 2.2) * 1.2, // breathing
+    lean: 0,
+  };
+}
+
+function walkStride(sim) {
+  const speedRatio = clamp01(Math.abs(sim.vx) / WALK.MAX_SPEED);
+  return WALK.STRIDE * (0.35 + 0.65 * speedRatio);
+}
+
+// Runs once per frame, BEFORE any pose is generated, so idle and walk read
+// the same plant state. On the swing->stance wrap the plant is committed at
+// the foot's current swing position — landing where the foot actually is,
+// never teleporting to an idealized landing point.
+export function commitPlants(sim) {
+  if (sim.mode !== 'walk') return;
+  const stride = walkStride(sim);
+  const groundY = sim.y;
+  const phaseL = sim.gaitPhase;
+  const phaseR = (sim.gaitPhase + 0.5) % 1;
+  const prevL = sim.prevGaitPhase;
+  const prevR = (sim.prevGaitPhase + 0.5) % 1;
+
+  if (crossedToStance(prevL, phaseL)) {
+    const swingPhase = Math.min(0.9999, Math.max(prevL, WALK.STANCE + 1e-4));
+    const p = footTarget(sim.x, groundY, sim.facing, swingPhase, sim.feetPlant.L, stride);
+    sim.feetPlant.L = { x: p.x, y: groundY };
+  }
+  if (crossedToStance(prevR, phaseR)) {
+    const swingPhase = Math.min(0.9999, Math.max(prevR, WALK.STANCE + 1e-4));
+    const p = footTarget(sim.x, groundY, sim.facing, swingPhase, sim.feetPlant.R, stride);
+    sim.feetPlant.R = { x: p.x, y: groundY };
+  }
+}
+
+function walkTargets(sim) {
+  const speedRatio = clamp01(Math.abs(sim.vx) / WALK.MAX_SPEED);
+  const stride = walkStride(sim);
+  const groundY = sim.y;
+  const phaseL = sim.gaitPhase;
+  const phaseR = (sim.gaitPhase + 0.5) % 1;
+
+  const feetL = footTarget(sim.x, groundY, sim.facing, phaseL, sim.feetPlant.L, stride);
+  const feetR = footTarget(sim.x, groundY, sim.facing, phaseR, sim.feetPlant.R, stride);
+
+  const hipY = sim.y - CHAR.legReach;
+  const shoulderY = hipY - CHAR.torso;
+  const armLen = CHAR.upperArm + CHAR.foreArm - 2;
+  // arms pendulum opposite their same-side leg
+  const angL = Math.sin(TAU * phaseR) * WALK.ARM_SWING * speedRatio;
+  const angR = Math.sin(TAU * phaseL) * WALK.ARM_SWING * speedRatio;
+  const handL = {
+    x: sim.x - CHAR.shoulderHalf + Math.sin(angL) * armLen * sim.facing,
+    y: shoulderY + Math.cos(angL) * armLen,
+  };
+  const handR = {
+    x: sim.x + CHAR.shoulderHalf + Math.sin(angR) * armLen * sim.facing,
+    y: shoulderY + Math.cos(angR) * armLen,
+  };
+
+  return {
+    feetL,
+    feetR,
+    handL,
+    handR,
+    hipLift: -Math.abs(Math.sin(sim.gaitPhase * TAU)) * WALK.BOB * speedRatio,
+    lean: sim.facing * 0.09 * speedRatio,
+  };
+}
+
+function climbTargets(sim, ladder, t) {
+  if (!ladder || !sim.climbLimbs) return idleTargets(sim, t);
+  const dir = sim.climbDir;
+  const phase = sim.climbPhase;
+  const L = sim.climbLimbs;
+  return {
+    handL: climbLimbTarget(L.handL, phase, dir, ladder, -1).target,
+    handR: climbLimbTarget(L.handR, phase, dir, ladder, 1).target,
+    feetL: climbLimbTarget(L.footL, phase, dir, ladder, -1).target,
+    feetR: climbLimbTarget(L.footR, phase, dir, ladder, 1).target,
+    hipLift: Math.sin(phase * TAU) * CLIMB.BOB,
+    lean: 0,
+  };
+}
+
+// Blend the three states' world-space targets by the ramped weights, then
+// hand one target set to the IK pass. Blending targets pre-IK cross-fades
+// idle/walk/climb with no popping.
+export function computeTargets(sim, ladder, t) {
+  commitPlants(sim);
+  const w = sim.weights;
+  const poses = [];
+  if (w.idle > 0.001) poses.push([w.idle, idleTargets(sim, t)]);
+  if (w.walk > 0.001) poses.push([w.walk, walkTargets(sim)]);
+  if (w.climb > 0.001) poses.push([w.climb, climbTargets(sim, ladder, t)]);
+
+  const out = {
+    feetL: { x: 0, y: 0 },
+    feetR: { x: 0, y: 0 },
+    handL: { x: 0, y: 0 },
+    handR: { x: 0, y: 0 },
+    hipLift: 0,
+    lean: 0,
+  };
+  let total = 0;
+  for (const [weight] of poses) total += weight;
+  for (const [weight, p] of poses) {
+    const k = weight / total;
+    for (const key of ['feetL', 'feetR', 'handL', 'handR']) {
+      out[key].x += p[key].x * k;
+      out[key].y += p[key].y * k;
+    }
+    out.hipLift += p.hipLift * k;
+    out.lean += p.lean * k;
+  }
+  out.climbing = w.climb > 0.5;
+  return out;
+}

--- a/src/app/experiences/inhabitant/character/render.js
+++ b/src/app/experiences/inhabitant/character/render.js
@@ -1,0 +1,44 @@
+// Writes solved joints straight to SVG nodes via refs — no React re-render.
+// This is the only file that knows what the character looks like, so swapping
+// in a designed SVG later means replacing CharacterSvg + this file only.
+
+const r2 = (v) => Math.round(v * 100) / 100;
+
+function setLine(el, a, b) {
+  if (!el) return;
+  el.setAttribute('x1', r2(a.x));
+  el.setAttribute('y1', r2(a.y));
+  el.setAttribute('x2', r2(b.x));
+  el.setAttribute('y2', r2(b.y));
+}
+
+export function drawCharacter(refs, joints, face) {
+  setLine(refs.torso, joints.hip, joints.shoulder);
+
+  // far-side limbs first (rendered at lower opacity for depth)
+  setLine(refs.thighR, joints.hipR, joints.kneeR);
+  setLine(refs.shinR, joints.kneeR, joints.footR);
+  setLine(refs.upperR, joints.shR, joints.elbR);
+  setLine(refs.foreR, joints.elbR, joints.handR);
+
+  setLine(refs.thighL, joints.hipL, joints.kneeL);
+  setLine(refs.shinL, joints.kneeL, joints.footL);
+  setLine(refs.upperL, joints.shL, joints.elbL);
+  setLine(refs.foreL, joints.elbL, joints.handL);
+
+  if (refs.headG) {
+    const deg = r2(((joints.lean * 1.2 + face.headTilt) * 180) / Math.PI);
+    refs.headG.setAttribute(
+      'transform',
+      `translate(${r2(joints.headC.x)} ${r2(joints.headC.y)}) rotate(${deg})`
+    );
+  }
+  if (refs.eyesG) {
+    // eyes sit toward the facing side; pupils shift along the look vector
+    const baseX = face.facing * 2.6;
+    refs.eyesG.setAttribute(
+      'transform',
+      `translate(${r2(baseX + face.lookX)} ${r2(-1.6 + face.lookY)}) scale(1 ${r2(face.blinkScale)})`
+    );
+  }
+}

--- a/src/app/experiences/inhabitant/character/rig.js
+++ b/src/app/experiences/inhabitant/character/rig.js
@@ -1,0 +1,42 @@
+import { CHAR } from '../constants';
+import { solveTwoBone } from './ik';
+
+// Solve the full body from blended world-space targets. The tree is shallow
+// enough to do explicitly: hips -> torso -> head, then IK the four limbs.
+export function solvePose(sim, targets) {
+  const hip = { x: sim.x, y: sim.y - CHAR.legReach + targets.hipLift };
+  const lean = targets.lean;
+  const shoulder = {
+    x: hip.x + Math.sin(lean) * CHAR.torso,
+    y: hip.y - Math.cos(lean) * CHAR.torso,
+  };
+  const headLen = CHAR.neck + CHAR.headR;
+  const headC = {
+    x: shoulder.x + Math.sin(lean * 1.5) * headLen,
+    y: shoulder.y - Math.cos(lean * 1.5) * headLen,
+  };
+
+  const hipL = { x: hip.x - CHAR.hipHalf, y: hip.y };
+  const hipR = { x: hip.x + CHAR.hipHalf, y: hip.y };
+  const shL = { x: shoulder.x - CHAR.shoulderHalf, y: shoulder.y };
+  const shR = { x: shoulder.x + CHAR.shoulderHalf, y: shoulder.y };
+
+  // knees bow toward facing; elbows bow backward when walking, outward when climbing
+  const kneeDir = -sim.facing || -1;
+  const elbowDirL = targets.climbing ? -1 : sim.facing || 1;
+  const elbowDirR = targets.climbing ? 1 : sim.facing || 1;
+
+  const legL = solveTwoBone(hipL, targets.feetL, CHAR.thigh, CHAR.shin, kneeDir);
+  const legR = solveTwoBone(hipR, targets.feetR, CHAR.thigh, CHAR.shin, kneeDir);
+  const armL = solveTwoBone(shL, targets.handL, CHAR.upperArm, CHAR.foreArm, elbowDirL);
+  const armR = solveTwoBone(shR, targets.handR, CHAR.upperArm, CHAR.foreArm, elbowDirR);
+
+  return {
+    hip, shoulder, headC, lean,
+    hipL, hipR, shL, shR,
+    kneeL: legL.knee, footL: legL.end,
+    kneeR: legR.knee, footR: legR.end,
+    elbL: armL.knee, handL: armL.end,
+    elbR: armR.knee, handR: armR.end,
+  };
+}

--- a/src/app/experiences/inhabitant/character/stateMachine.js
+++ b/src/app/experiences/inhabitant/character/stateMachine.js
@@ -1,0 +1,182 @@
+import { WALK, CLIMB, LADDER } from '../constants';
+import { arrive } from './locomotion';
+import { makeClimbLimbs, stepClimbLimb } from './climb';
+
+export function createSim(x, y) {
+  return {
+    x, y, // feet point, stage-local px
+    vx: 0,
+    vy: 0,
+    facing: 1,
+    mode: 'idle', // 'idle' | 'walk' | 'climb'
+    queue: [],
+    current: null,
+    pendingClick: null, // click received mid-climb, re-planned after the ladder ends
+    gaitPhase: 0,
+    prevGaitPhase: 0,
+    climbPhase: 0,
+    prevClimbPhase: 0,
+    feetPlant: { L: { x: x - 8, y }, R: { x: x + 8, y } },
+    climbLimbs: null,
+    climbDir: 1,
+    weights: { idle: 1, walk: 0, climb: 0 },
+  };
+}
+
+// The ladder is created at PLAN time, not climb time, so it grows while the
+// character is still walking over — it's already standing when they arrive.
+function makeClimbAction(sim, click) {
+  const goingDown = click.y > sim.y;
+  const topFeet = Math.min(sim.y, click.y);
+  const bottomFeet = Math.max(sim.y, click.y);
+  const ladder = {
+    x: click.x,
+    railTop: topFeet - LADDER.EXTEND,
+    railBottom: bottomFeet + 4,
+    feetTop: topFeet,
+    feetBottom: bottomFeet,
+    rungSpacing: LADDER.RUNG_SPACING,
+    growFrom: goingDown ? 'top' : 'bottom',
+    width: LADDER.WIDTH,
+  };
+  return {
+    type: 'climb',
+    x: click.x,
+    toY: click.y,
+    startY: sim.y,
+    ladder,
+    dir: goingDown ? 1 : -1,
+    growLeft: LADDER.GROW_TIME,
+  };
+}
+
+// Click -> action queue. Floor-free: a roughly-level click is a pure walk;
+// anything else is walk-to-x then climb-to-y.
+export function plan(sim, click, env) {
+  // Mid-climb: never hop off. Ride this ladder to its end in the click's
+  // direction — reversing on the same ladder if needed — then re-plan.
+  if (sim.mode === 'climb' && sim.current && sim.current.type === 'climb' && sim.current.ladder) {
+    const a = sim.current;
+    if (Math.abs(sim.y - a.startY) >= 8) {
+      if (click.y > sim.y) {
+        a.toY = a.ladder.feetBottom;
+        a.dir = 1;
+      } else {
+        a.toY = a.ladder.feetTop;
+        a.dir = -1;
+      }
+      sim.pendingClick = click;
+      return;
+    }
+    // still at the base (grow wait / first step) — cancel this climb outright
+    env.removeLadder();
+    sim.climbLimbs = null;
+    sim.current = null;
+    sim.vy = 0;
+    sim.mode = 'idle';
+  }
+
+  // Replacing a plan that had a climb still ahead: its pre-spawned ladder goes.
+  if (sim.queue.some((q) => q.type === 'climb')) {
+    env.removeLadder();
+  }
+
+  const actions = [{ type: 'walk', x: click.x }];
+  if (Math.abs(click.y - sim.y) >= CLIMB.THRESHOLD) {
+    const climb = makeClimbAction(sim, click);
+    actions.push(climb);
+    env.spawnLadder(climb.ladder);
+  }
+  sim.queue = actions;
+  sim.current = null; // walk retargets smoothly; arrive absorbs the velocity discontinuity
+  sim.pendingClick = null;
+}
+
+function startAction(sim, action) {
+  sim.current = action;
+  sim.mode = action.type;
+}
+
+export function advance(sim, dt, env) {
+  // a pre-spawned ladder keeps growing while the character walks to it
+  for (const q of sim.queue) {
+    if (q.type === 'climb' && q.growLeft > 0) q.growLeft -= dt;
+  }
+
+  if (!sim.current) {
+    const next = sim.queue.shift();
+    if (next) {
+      startAction(sim, next);
+    } else if (sim.mode !== 'idle') {
+      sim.mode = 'idle';
+    }
+  }
+
+  const a = sim.current;
+  if (!a) {
+    // idle: bleed off any residual velocity
+    sim.vx *= Math.max(0, 1 - dt * 10);
+    return;
+  }
+
+  if (a.type === 'walk') {
+    const r = arrive(sim.x, sim.vx, a.x, WALK.MAX_SPEED, WALK.ACCEL, WALK.SLOW_RADIUS, dt);
+    sim.x = r.pos;
+    sim.vx = r.vel;
+    if (Math.abs(sim.vx) > WALK.FACING_DEADZONE) sim.facing = Math.sign(sim.vx);
+    sim.prevGaitPhase = sim.gaitPhase;
+    const speedRatio = Math.abs(sim.vx) / WALK.MAX_SPEED;
+    const stride = WALK.STRIDE * (0.35 + 0.65 * speedRatio);
+    sim.gaitPhase = (sim.gaitPhase + (Math.abs(sim.vx) * dt) / stride) % 1;
+    if (Math.abs(a.x - sim.x) < 0.6 && Math.abs(sim.vx) < 4) {
+      sim.x = a.x;
+      sim.vx = 0;
+      sim.current = null;
+    }
+    return;
+  }
+
+  if (a.type === 'climb') {
+    const ladder = a.ladder;
+    // ease onto the ladder's x while it grows / while climbing
+    sim.x += (ladder.x - sim.x) * Math.min(1, dt * 10);
+
+    if (a.growLeft > 0) {
+      a.growLeft -= dt;
+      return;
+    }
+    if (!sim.climbLimbs) {
+      const shoulderY = sim.y - 61; // legReach + torso; only used to seed grips
+      sim.climbLimbs = makeClimbLimbs(ladder, sim, shoulderY);
+      sim.climbPhase = 0;
+      sim.prevClimbPhase = 0;
+    }
+
+    const r = arrive(sim.y, sim.vy, a.toY, CLIMB.SPEED, CLIMB.ACCEL, CLIMB.SLOW_RADIUS, dt);
+    sim.y = r.pos;
+    sim.vy = r.vel;
+    sim.climbDir = a.dir;
+    sim.prevClimbPhase = sim.climbPhase;
+    sim.climbPhase = (sim.climbPhase + (Math.abs(sim.vy) * dt) / ladder.rungSpacing) % 1;
+
+    for (const key of ['handL', 'handR', 'footL', 'footR']) {
+      stepClimbLimb(sim.climbLimbs[key], sim.prevClimbPhase, sim.climbPhase, a.dir, ladder);
+    }
+
+    if (Math.abs(a.toY - sim.y) < 0.6 && Math.abs(sim.vy) < 4) {
+      sim.y = a.toY;
+      sim.vy = 0;
+      sim.climbLimbs = null;
+      sim.current = null;
+      sim.feetPlant.L = { x: sim.x - 8, y: sim.y };
+      sim.feetPlant.R = { x: sim.x + 8, y: sim.y };
+      env.removeLadder();
+      if (sim.pendingClick) {
+        // dismounted at the ladder's end; now honor the interrupting click
+        const click = sim.pendingClick;
+        sim.pendingClick = null;
+        plan(sim, click, env);
+      }
+    }
+  }
+}

--- a/src/app/experiences/inhabitant/constants.js
+++ b/src/app/experiences/inhabitant/constants.js
@@ -1,0 +1,67 @@
+// All tunables for the Inhabitant experience in one place.
+// Units: px, seconds, radians. y points down.
+
+export const CHAR = {
+  headR: 10,
+  neck: 6,
+  torso: 30,
+  thigh: 17,
+  shin: 17,
+  upperArm: 13,
+  foreArm: 13,
+  hipHalf: 4, // half hip width
+  shoulderHalf: 7, // half shoulder width
+  legReach: 31, // hip height above feet when standing (keeps a slight knee bend; < thigh+shin)
+  W: 64, // obstacle AABB width
+  H: 96, // obstacle AABB height above the feet point
+};
+
+export const WALK = {
+  MAX_SPEED: 210, // px/s
+  ACCEL: 850,
+  SLOW_RADIUS: 70,
+  STRIDE: 46, // full cycle distance at speed
+  STEP_HEIGHT: 11,
+  STANCE: 0.6, // fraction of gait cycle a foot is planted
+  BOB: 2.5,
+  ARM_SWING: 0.55, // pendulum amplitude, radians
+  FACING_DEADZONE: 12, // px/s before facing flips
+};
+
+export const CLIMB = {
+  SPEED: 85,
+  ACCEL: 320,
+  SLOW_RADIUS: 36,
+  THRESHOLD: 36, // vertical click distance below which we just walk
+  HOLD: 0.55, // fraction of climb cycle a limb grips
+  REACH_BOW: 6, // sideways bow of a limb mid-reach
+  BOB: 2,
+};
+
+export const LADDER = {
+  WIDTH: 22, // rail-to-rail
+  RUNG_SPACING: 26,
+  EXTEND: 64, // rails continue this far above the top feet position so hands have rungs
+  GROW_TIME: 0.35,
+  FADE_TIME: 0.3,
+};
+
+export const TEXT = {
+  LINE_H: 28, // must match the CSS line-height on the pooled spans
+  GUTTER: 18, // clearance between obstacle and text
+  MIN_RUN: 56, // skip a side narrower than this (avoids 1-2 char slivers)
+  REFLOW_EPS: 3, // obstacle must move this far before re-layout
+  POOL: 96, // pooled DOM line count
+  X_STIFFNESS: 190, // per-line x spring
+  X_DAMPING: 24,
+};
+
+export const STAGE = {
+  COL_W: 804, // text column width (viewport permitting); the stage itself fills the viewport
+  PARA_TOP: 150,
+  PAD_X: 28,
+  PAD_BOTTOM: 24,
+  SLACK_LINES: 10, // extra line bands so obstacle-displaced text never runs out of room
+};
+
+export const BLEND_RATE = 7; // state-weight ramp, 1/s

--- a/src/app/experiences/inhabitant/core/loop.js
+++ b/src/app/experiences/inhabitant/core/loop.js
@@ -1,0 +1,48 @@
+// The single rAF clock. dt is clamped so tab-switches don't launch the
+// character across the screen, and the loop pauses when the tab is hidden
+// or the stage scrolls offscreen.
+
+export function startLoop(tick, { observe = null } = {}) {
+  let raf = 0;
+  let last = 0;
+  let stopped = false;
+  let hidden = false;
+  let offscreen = false;
+
+  function frame(now) {
+    if (stopped) return;
+    if (!hidden && !offscreen) {
+      const dt = Math.min(last ? now - last : 16, 50) / 1000;
+      last = now;
+      tick(dt, now / 1000);
+    } else {
+      last = 0; // avoid a dt spike on resume
+    }
+    raf = requestAnimationFrame(frame);
+  }
+
+  function onVisibility() {
+    hidden = document.visibilityState === 'hidden';
+    if (hidden) last = 0;
+  }
+
+  document.addEventListener('visibilitychange', onVisibility);
+
+  let io = null;
+  if (observe && typeof IntersectionObserver !== 'undefined') {
+    io = new IntersectionObserver(([entry]) => {
+      offscreen = !entry.isIntersecting;
+      if (offscreen) last = 0;
+    });
+    io.observe(observe);
+  }
+
+  raf = requestAnimationFrame(frame);
+
+  return function stop() {
+    stopped = true;
+    cancelAnimationFrame(raf);
+    document.removeEventListener('visibilitychange', onVisibility);
+    if (io) io.disconnect();
+  };
+}

--- a/src/app/experiences/inhabitant/core/spring.js
+++ b/src/app/experiences/inhabitant/core/spring.js
@@ -1,0 +1,13 @@
+export function createSpring(value = 0) {
+  return { value, velocity: 0 };
+}
+
+export function stepSpring(s, target, stiffness, damping, dt) {
+  s.velocity += (-stiffness * (s.value - target) - damping * s.velocity) * dt;
+  s.value += s.velocity * dt;
+}
+
+export function snapSpring(s, value) {
+  s.value = value;
+  s.velocity = 0;
+}

--- a/src/app/experiences/inhabitant/page.js
+++ b/src/app/experiences/inhabitant/page.js
@@ -1,0 +1,32 @@
+import { Geist, Instrument_Serif } from 'next/font/google';
+import Stage from './Stage';
+
+// Page-scoped fonts: pretext measures against the exact rendered font, so the
+// body font is read from computed style at runtime (see Stage.jsx).
+const geist = Geist({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-geist',
+  display: 'swap',
+});
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ['latin'],
+  weight: '400',
+  variable: '--font-instrument',
+  display: 'swap',
+});
+
+export const metadata = {
+  title: 'The Inhabitant - UiGlow',
+  description:
+    'A procedurally animated character that walks and climbs through a paragraph that reflows around it in real time.',
+};
+
+export default function InhabitantPage() {
+  return (
+    <div className={`${geist.variable} ${instrumentSerif.variable}`}>
+      <Stage />
+    </div>
+  );
+}

--- a/src/app/experiences/inhabitant/text/obstacle.js
+++ b/src/app/experiences/inhabitant/text/obstacle.js
@@ -1,0 +1,41 @@
+import { CHAR, TEXT } from '../constants';
+
+// One obstacle rect per frame: the character AABB unioned with the ladder's
+// thin vertical rect. The text only cares about horizontal intrusion per band.
+
+export function buildObstacle(sim, ladder) {
+  const half = CHAR.W / 2;
+  let x0 = sim.x - half;
+  let y0 = sim.y - CHAR.H;
+  let x1 = sim.x + half;
+  let y1 = sim.y + 6;
+  if (ladder) {
+    const lHalf = ladder.width / 2 + 4;
+    x0 = Math.min(x0, ladder.x - lHalf);
+    x1 = Math.max(x1, ladder.x + lHalf);
+    y0 = Math.min(y0, ladder.railTop);
+    y1 = Math.max(y1, ladder.railBottom);
+  }
+  return { x0, y0, x1, y1 };
+}
+
+export function obstacleMoved(a, b) {
+  if (!a || !b) return a !== b;
+  return (
+    Math.abs(a.x0 - b.x0) > TEXT.REFLOW_EPS ||
+    Math.abs(a.y0 - b.y0) > TEXT.REFLOW_EPS ||
+    Math.abs(a.x1 - b.x1) > TEXT.REFLOW_EPS ||
+    Math.abs(a.y1 - b.y1) > TEXT.REFLOW_EPS
+  );
+}
+
+// Free horizontal runs in a line band, given the obstacle.
+export function bandFree(band, col, ob) {
+  const intrudes =
+    ob && ob.y0 < band.bottom && ob.y1 > band.top && ob.x1 > col.x0 && ob.x0 < col.x1;
+  if (!intrudes) return { leftW: col.x1 - col.x0, rightX: col.x0, rightW: 0 };
+  const leftW = Math.max(0, ob.x0 - col.x0 - TEXT.GUTTER);
+  const rightX = ob.x1 + TEXT.GUTTER;
+  const rightW = Math.max(0, col.x1 - rightX);
+  return { leftW, rightX, rightW };
+}

--- a/src/app/experiences/inhabitant/text/reflow.js
+++ b/src/app/experiences/inhabitant/text/reflow.js
@@ -1,0 +1,71 @@
+import {
+  prepareWithSegments,
+  layoutNextLineRange,
+  materializeLineRange,
+  measureLineStats,
+} from '@chenglou/pretext';
+import { TEXT } from '../constants';
+import { bandFree } from './obstacle';
+
+export const pretextSupported = () =>
+  typeof Intl !== 'undefined' &&
+  typeof Intl.Segmenter === 'function' &&
+  typeof document !== 'undefined' &&
+  typeof document.createElement('canvas').getContext === 'function';
+
+// The one-time expensive pass. The font string must match the rendered CSS
+// exactly, so the caller reads it off a live node's computed style.
+export function prepareText(text, fontString) {
+  return prepareWithSegments(text, fontString);
+}
+
+// Unobstructed line count for a given column width — used to size the stage.
+export function naturalLineCount(prepared, maxWidth) {
+  return measureLineStats(prepared, maxWidth).lineCount;
+}
+
+// Two-sided channel reflow. pretext gives variable width per line but not a
+// native hole-in-the-middle, so an intruded band lays out a left run then a
+// right run, both consuming the same cursor stream sequentially.
+export function reflow(prepared, ob, geom) {
+  const out = [];
+  let cursor = { segmentIndex: 0, graphemeIndex: 0 };
+  let y = geom.top;
+  const col = { x0: geom.x0, x1: geom.x1 };
+  const maxY = geom.top + geom.maxH;
+
+  while (y < maxY) {
+    const { leftW, rightX, rightW } = bandFree({ top: y, bottom: y + TEXT.LINE_H }, col, ob);
+    const before = cursor;
+
+    if (rightW === 0) {
+      // no intrusion: one full line
+      if (leftW > TEXT.MIN_RUN) {
+        const r = layoutNextLineRange(prepared, cursor, leftW);
+        if (!r) break;
+        out.push({ x: col.x0, y, text: materializeLineRange(prepared, r).text });
+        cursor = r.end;
+      }
+    } else {
+      if (leftW > TEXT.MIN_RUN) {
+        const l = layoutNextLineRange(prepared, cursor, leftW);
+        if (l) {
+          out.push({ x: col.x0, y, text: materializeLineRange(prepared, l).text });
+          cursor = l.end;
+        }
+      }
+      if (rightW > TEXT.MIN_RUN) {
+        const rr = layoutNextLineRange(prepared, cursor, rightW);
+        if (rr) {
+          out.push({ x: rightX, y, text: materializeLineRange(prepared, rr).text });
+          cursor = rr.end;
+        }
+      }
+    }
+
+    // if nothing was consumed (band fully blocked), leave a clean hole and continue
+    y += TEXT.LINE_H;
+    if (cursor === before) continue;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

New experience at `/experiences/inhabitant` — a procedurally animated character that lives inside a paragraph. It walks and climbs wherever you click, and the text reflows around it (and its ladder) as a live obstacle, every frame.

- **Character sim**: arrive-steering locomotion, planted feet with zero stance slide, two-bone IK (law of cosines), idle/walk/climb pose blending, pointer look-at springs, blinks, breathing idle. Placeholder line-figure rig — visuals isolated to `CharacterSvg.jsx` + `render.js` for a later SVG swap.
- **Ladder**: sized exactly to the click's travel distance, grows from top when descending / bottom when ascending. Spawned at plan time so it's already standing when the character arrives. Mid-climb clicks ride the ladder to its end (reversing on the same ladder if the click is the other way) before re-planning — no mid-air hops.
- **Text**: [`@chenglou/pretext`](https://github.com/chenglou/pretext) lays out the paragraph arithmetically (no DOM reflow); intruded line bands split into left/right runs around the obstacle, rendered via a pooled set of spans with per-line x springs so lines flow instead of snapping. Reflow is gated on obstacle movement.
- **Stage**: entire viewport is clickable/walkable; the text column stays centered and the stage height is derived from the measured text.
- **Fallbacks**: reduced-motion / missing `Intl.Segmenter` renders a static scene; touch/narrow viewports get a desktop-only notice; screen readers get a real in-order copy of the text.

One rAF clock drives everything; per-frame updates are direct ref writes (React re-renders only for ladder presence and mode).

## Test plan

- [x] `npm run build` — clean static export (23 kB route)
- [x] `next lint` on the new directory — no warnings
- [x] Headless sim tests: exact walk/climb arrivals, zero stance-foot slide, ladder pre-spawn during walk, walk-retarget respawn, same-direction and reverse mid-climb interrupts, base-cancel path
- [ ] Manual: click around at `/experiences/inhabitant` in light + dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)