### PR TITLE
Add Vision Scene UI exploration and related polish.

### DIFF
--- a/skills/add-d1-website-reference/SKILL.md
+++ b/skills/add-d1-website-reference/SKILL.md
@@ -12,8 +12,9 @@ Use the Cloudflare MCP for every live D1 read and write. Always use a direct D1 
 1. Use the Cloudflare API MCP search tool to confirm the D1 query endpoint if needed.
 2. List the account's D1 databases through the Cloudflare API MCP. Select the database named `uiglow-bookmarks` unless the user directs otherwise.
 3. Directly query `bookmarks` first. Check for the URL and preserve existing records. Do not infer the database state from dashboard metadata or local migrations.
-4. Create the bookmark, required tags, and `bookmark_tags` relations with an idempotent D1 batch query. Use stable UUIDs or URL-derived IDs, `INSERT OR IGNORE` for tags and relations, and only update an existing bookmark after confirming the user wants its editorial fields changed.
-5. Store the canonical HTTPS URL, hostname, a short title, and a compact note in the user's voice. Use lowercase kebab-case tag names and readable labels.
-6. Verify the saved bookmark and its tags with a final direct D1 `SELECT` query. Report the title, URL, and tags.
+4. Retrieve the page's public metadata and look for `<meta property="og:image">`. Resolve a relative image URL against the canonical page URL. Store the resulting HTTPS URL in `image_url` when it is valid; otherwise store `NULL`. Do not invent a preview URL.
+5. Create the bookmark, required tags, and `bookmark_tags` relations with an idempotent D1 batch query. Include `image_url` in the bookmark insert. Use stable UUIDs or URL-derived IDs, `INSERT OR IGNORE` for tags and relations, and only update an existing bookmark after confirming the user wants its editorial fields changed.
+6. Store the canonical HTTPS URL, hostname, a short title, and a compact note in the user's voice. Use lowercase kebab-case tag names and readable labels.
+7. Verify the saved bookmark, its tags, and `image_url` with a final direct D1 `SELECT` query. Report the title, URL, tags, and whether an OG image was saved.
 
 Use direct Cloudflare MCP D1 queries as the only persistence mechanism. Do not create or update repository migrations for website references unless the user explicitly asks for a database bootstrap file.

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -72,6 +72,19 @@ export default function RootLayout({ children }) {
             __html: `
               // Ensure light mode is set immediately (before React hydration)
               document.documentElement.classList.remove('dark');
+
+              // A pathname beginning with // is parsed by Next's client router as
+              // a protocol-relative URL (for example, //vault/links becomes
+              // https://vault/links). Normalize accidental duplicate slashes
+              // before hydration so navigation remains on this origin.
+              if (window.location.pathname.startsWith('//')) {
+                const normalizedPathname = window.location.pathname.replace(/^\\/+/, '/');
+                window.history.replaceState(
+                  window.history.state,
+                  '',
+                  normalizedPathname + window.location.search + window.location.hash
+                );
+              }
             `,
           }}
         />

--- a/src/app/ui-interactions/layout.js
+++ b/src/app/ui-interactions/layout.js
@@ -8,7 +8,7 @@ import { navItems } from "./navigation-config"
 export default function UIExplorationsLayout({ children }) {
   const pathname = usePathname()
   const currentItem = navItems.find(item => item.href === pathname)
-  const title = currentItem?.label || 'UI Interactions'
+  const title = currentItem?.label || 'UI Explorations'
 
   return (
     <div className="flex flex-col h-screen">

--- a/src/app/ui-interactions/navigation-config.js
+++ b/src/app/ui-interactions/navigation-config.js
@@ -1,4 +1,5 @@
 export const navItems = [
+    { label: "Vision Scene",  href: "/ui-interactions/vision-scene" },
     { label: "Image Stack",    href: "/ui-interactions/img-stack" },
     { label: "Image Tiles",    href: "/ui-interactions/img-tiles" },
     { label: "Image Light",    href: "/ui-interactions/img-light" },

--- a/src/app/ui-interactions/vision-scene/page.js
+++ b/src/app/ui-interactions/vision-scene/page.js
@@ -1,0 +1,16 @@
+import VisionScene from '@/components/vision-scene/VisionScene';
+
+export default function VisionScenePage() {
+  return (
+    <main className="min-h-full bg-[#fafaf9] px-5 py-8 sm:px-10">
+      <section className="mx-auto flex min-h-[calc(100vh-9rem)] max-w-6xl flex-col justify-center">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[.22em] text-violet-700">UI exploration</p>
+        <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-900 sm:text-5xl">Vision Scene</h1>
+        <p className="mt-3 max-w-xl text-slate-600">A generative field rises into a pair of mountains before resolving into a calm orbit around the UiGlow mark.</p>
+        <div className="mt-8 h-[440px] overflow-hidden rounded-3xl border border-violet-100 bg-gradient-to-br from-white via-violet-50 to-fuchsia-50 shadow-sm sm:h-[560px]">
+          <VisionScene />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/effects/BreathingHero.jsx
+++ b/src/components/effects/BreathingHero.jsx
@@ -10,7 +10,7 @@ export default function BreathingHero() {
           <div className='flex flex-col items-center'>
             <h1 className='font-heading text-2xl text-orange-950 font-bold dark:text-orange-200 tracking-wider'>Motion, Pixels, & Play</h1>
             <p className="mt-2 text-base font-light leading-relaxed tracking-wider font-sans dark:text-slate-300 text-slate-900 text-center">
-            A playground for exploring ideas across motion design, interactive experiences, React components, and curious little animations. Built with love and a sprinkle of code magic.
+            A playground for exploring ideas across motion design, interactive experiences, UI explorations, and curious little animations. Built with love and a sprinkle of code magic.
             </p>
           </div>
         </div>

--- a/src/components/gallery/GalleryContent.jsx
+++ b/src/components/gallery/GalleryContent.jsx
@@ -13,6 +13,7 @@ const ComponentSkeleton = () => (
 const componentMap = {
   Clock: dynamic(() => import('@/app/experiences/clock/Clock')),
   CoinFlip: dynamic(() => import('@/app/svg-animations/coinflip/CoinFlip')),
+  VisionScene: dynamic(() => import('@/components/vision-scene/VisionScene')),
 };
 
 function GalleryContent({ contentType, content, component, componentProps, title }) {

--- a/src/components/vision-scene/VisionScene.jsx
+++ b/src/components/vision-scene/VisionScene.jsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import UIGlowLogo from '@/components/Logo';
+
+const vertexShader = `#version 300 es
+layout(location = 0) in vec3 a_position;
+uniform float u_time;
+uniform float u_pixelRatio;
+uniform mat4 u_projection;
+out float v_alpha;
+
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
+float noise(vec2 p) {
+  vec2 i = floor(p), f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  return mix(mix(hash(i), hash(i + vec2(1., 0.)), f.x), mix(hash(i + vec2(0., 1.)), hash(i + vec2(1., 1.)), f.x), f.y);
+}
+float terrain(vec2 p) {
+  float a = noise(p * 5.0) * 0.42 + noise(p * 10.0) * 0.18;
+  float peakA = exp(-length(p - vec2(-.18, .05)) * 7.0);
+  float peakB = exp(-length(p - vec2(.22, -.08)) * 8.0);
+  return a * max(peakA, peakB);
+}
+void main() {
+  float rise = smoothstep(0.0, 2.6, u_time);
+  float overhead = smoothstep(3.1, 5.0, u_time);
+  float merge = smoothstep(5.6, 8.6, u_time);
+  vec2 p = a_position.xz;
+  float height = terrain(p + .5) * rise;
+  vec2 polar = normalize(p + vec2(.0001)) * mix(.12, .43, hash(p * 45.0));
+  polar += vec2(cos(hash(p * 8.0) * 6.283), sin(hash(p * 12.0) * 6.283)) * .035;
+  vec3 terrainPos = vec3(p.x, height, p.y);
+  vec3 cloudPos = vec3(polar.x, 0.01, polar.y);
+  vec3 pos = mix(terrainPos, cloudPos, merge);
+  float c = cos(overhead * .8), s = sin(overhead * .8);
+  pos.yz = mat2(c, -s, s, c) * pos.yz;
+  gl_Position = u_projection * vec4(pos, 1.0);
+  float distanceFade = 1.0 - smoothstep(.38, .72, length(p));
+  v_alpha = distanceFade * mix(.72, .92, merge);
+  gl_PointSize = (1.4 + hash(p * 92.0) * 1.4) * u_pixelRatio;
+}`;
+
+const fragmentShader = `#version 300 es
+precision highp float;
+in float v_alpha;
+out vec4 color;
+void main() {
+  float d = length(gl_PointCoord - .5) * 2.;
+  float a = smoothstep(1., .35, d) * v_alpha;
+  color = vec4(vec3(.17, .12, .28), a);
+}`;
+
+function createShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(shader));
+  return shader;
+}
+
+function createProgram(gl) {
+  const program = gl.createProgram();
+  gl.attachShader(program, createShader(gl, gl.VERTEX_SHADER, vertexShader));
+  gl.attachShader(program, createShader(gl, gl.FRAGMENT_SHADER, fragmentShader));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(program));
+  return program;
+}
+
+function makePoints(size = 132) {
+  const points = new Float32Array(size * size * 3);
+  let offset = 0;
+  for (let y = 0; y < size; y += 1) for (let x = 0; x < size; x += 1) {
+    const jitter = (Math.sin(x * 13.3 + y * 27.1) * 43758.5) % 1;
+    points[offset++] = x / (size - 1) - .5 + jitter * .002;
+    points[offset++] = 0;
+    points[offset++] = y / (size - 1) - .5 + jitter * .002;
+  }
+  return points;
+}
+
+function orthographic(out, left, right, bottom, top, near, far) {
+  out[0] = 2 / (right - left); out[1] = 0; out[2] = 0; out[3] = 0;
+  out[4] = 0; out[5] = 2 / (top - bottom); out[6] = 0; out[7] = 0;
+  out[8] = 0; out[9] = 0; out[10] = -2 / (far - near); out[11] = 0;
+  out[12] = -(right + left) / (right - left); out[13] = -(top + bottom) / (top - bottom); out[14] = -(far + near) / (far - near); out[15] = 1;
+}
+
+export default function VisionScene({ className = '' }) {
+  const canvasRef = useRef(null);
+  const frameRef = useRef(null);
+  const startRef = useRef(null);
+  const [logoVisible, setLogoVisible] = useState(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const gl = canvas?.getContext('webgl2', { alpha: true, antialias: true });
+    if (!gl) return undefined;
+    let program;
+    try { program = createProgram(gl); } catch { return undefined; }
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    const points = makePoints();
+    gl.bufferData(gl.ARRAY_BUFFER, points, gl.STATIC_DRAW);
+    gl.useProgram(program);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    const time = gl.getUniformLocation(program, 'u_time');
+    const ratio = gl.getUniformLocation(program, 'u_pixelRatio');
+    const projection = gl.getUniformLocation(program, 'u_projection');
+    const matrix = new Float32Array(16);
+    let active = true;
+    const observer = new IntersectionObserver(([entry]) => { active = entry.isIntersecting; }, { threshold: .15 });
+    observer.observe(canvas);
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const width = Math.max(1, Math.floor(canvas.clientWidth * dpr));
+      const height = Math.max(1, Math.floor(canvas.clientHeight * dpr));
+      if (canvas.width !== width || canvas.height !== height) { canvas.width = width; canvas.height = height; }
+      gl.viewport(0, 0, width, height);
+      const aspect = width / height;
+      orthographic(matrix, -aspect * .62, aspect * .62, -.62, .62, -2, 2);
+      gl.uniformMatrix4fv(projection, false, matrix);
+      gl.uniform1f(ratio, dpr);
+    };
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(canvas);
+    resize();
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const render = (now) => {
+      if (startRef.current === null) startRef.current = now;
+      const elapsed = reduced ? 9 : ((now - startRef.current) / 1000) % 14;
+      const sceneTime = elapsed > 12.5 ? 0 : elapsed;
+      setLogoVisible(sceneTime > 4.8 && sceneTime < 12.5);
+      if (active || reduced) {
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.uniform1f(time, sceneTime);
+        gl.drawArrays(gl.POINTS, 0, points.length / 3);
+      }
+      if (!reduced) frameRef.current = requestAnimationFrame(render);
+    };
+    frameRef.current = requestAnimationFrame(render);
+    return () => { cancelAnimationFrame(frameRef.current); observer.disconnect(); resizeObserver.disconnect(); gl.deleteBuffer(buffer); gl.deleteProgram(program); };
+  }, []);
+
+  return <div className={`relative h-full w-full overflow-hidden ${className}`} aria-label="Rising dot-field mountain animation">
+    <canvas ref={canvasRef} className="h-full w-full" />
+    <div className="pointer-events-none absolute left-1/2 top-1/2" style={{ transform: 'translate(-50%, -50%)' }}>
+      <div className={`flex h-16 w-16 items-center justify-center rounded-full bg-white/85 shadow-[0_10px_40px_rgba(80,45,120,.16)] backdrop-blur transition-all duration-700 ${logoVisible ? 'scale-100 opacity-100' : 'scale-75 opacity-0'}`}><UIGlowLogo variant="mini" /></div>
+    </div>
+  </div>;
+}

--- a/src/data/galleryData.js
+++ b/src/data/galleryData.js
@@ -101,6 +101,12 @@ export const galleryCards = [
     size: { width: 240, height: 170 },
     link: '/ui-interactions/chat-interface',
   }),
+  componentCard('vision-scene', 'VisionScene', {
+    title: 'Vision Scene',
+    size: { width: 240, height: 170 },
+    link: '/ui-interactions/vision-scene',
+    backgroundColor: '#faf5ff',
+  }),
 
   componentCard('coinflip', 'CoinFlip', {
     title: 'Coin Flip',


### PR DESCRIPTION
Wire the new interactive demo into gallery and nav, capture OG images for D1 bookmarks, and normalize accidental double-slash pathnames before hydration.